### PR TITLE
Make the change of canvas size happen after the page is loaded

### DIFF
--- a/draw/index.html
+++ b/draw/index.html
@@ -5,6 +5,9 @@
     *{
         margin: 0;
         padding: 0;
+        height: 100%;
+        overflow: hidden;
+        color: white;
     }
     </style>
 </head>
@@ -12,14 +15,16 @@
     <canvas id="canvas"></canvas>
     <script>
         const canvas = document.getElementById("canvas");
-        canvas.height = window.innerHeight;
-        canvas.width = window.innerWidth;
         const ctx = canvas.getContext("2d");
-        ctx.lineWidth = 5;
-
         let pX = null;
         let pY = null;
         let isDrawing = false;
+
+        window.addEventListener("load", () => {
+            canvas.height = window.innerHeight;
+            canvas.width = window.innerWidth;
+            ctx.lineWidth = 5;
+        });
 
         window.addEventListener("mousedown", (e) => {
             isDrawing = true;


### PR DESCRIPTION
The `window.innerWidth` and `window.innerHeight` is not consistent before and after the page is fully loaded. So the part of changing of canvas size is moved to after the page is loaded. Tested on Firefox android 101.1.1 (Build #2015882827).
See [this](https://bugzilla.mozilla.org/show_bug.cgi?id=771575) for more Information.